### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   inputs = {
     # Import the desired Nix channel. Defaults to unstable, which uses a fully tested rolling release model.
-    #   You can find a list of channels at https://nixos.wiki/wiki/Nix_channels
+    #   You can find a list of channels at https://wiki.nixos.org/wiki/Nix_channels
     #   To follow a different channel, replace `nixos-unstable` with the channel name, e.g. `nixos-24.05`.
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 

--- a/hosts/Pihole/hardware-configuration.nix
+++ b/hosts/Pihole/hardware-configuration.nix
@@ -1,5 +1,5 @@
 # Raspberry Pi 4B
-# See https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_4
+# See https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_4
 {
   config,
   lib,

--- a/modules/services/msmtp.nix
+++ b/modules/services/msmtp.nix
@@ -1,4 +1,4 @@
-# See https://nixos.wiki/wiki/Msmtp
+# See https://wiki.nixos.org/wiki/Msmtp
 { config, lib, ... }:
 
 let

--- a/modules/services/nginx.nix
+++ b/modules/services/nginx.nix
@@ -21,7 +21,7 @@ in
     services.nginx = {
       enable = true;
 
-      # Use recommended settings per https://nixos.wiki/wiki/Nginx#Hardened_setup_with_TLS_and_HSTS_preloading
+      # Use recommended settings per https://wiki.nixos.org/wiki/Nginx#Hardened_setup_with_TLS_and_HSTS_preloading
       recommendedGzipSettings = true;
       recommendedOptimisation = true;
       recommendedTlsSettings = true;

--- a/modules/system/bootloader.nix
+++ b/modules/system/bootloader.nix
@@ -43,7 +43,7 @@ in
         };
       })
 
-      # Set up TPM if enabled. See https://nixos.wiki/wiki/TPM
+      # Set up TPM if enabled. See https://wiki.nixos.org/wiki/TPM
       (lib.mkIf (cfg.tpm2.enable) {
         boot.initrd = {
           # Enable systemd for TPM auto-unlocking

--- a/modules/system/gpu/nvidia.nix
+++ b/modules/system/gpu/nvidia.nix
@@ -46,11 +46,11 @@ in
     assertions = [
       {
         assertion = (cfg.hybrid.busIDs.nvidia != "");
-        message = "You need to define a bus ID for your Nvidia GPU. To learn how to find the bus ID, see https://nixos.wiki/wiki/Nvidia#Configuring_Optimus_PRIME:_Bus_ID_Values_.28Mandatory.29.";
+        message = "You need to define a bus ID for your Nvidia GPU. To learn how to find the bus ID, see https://wiki.nixos.org/wiki/Nvidia#Configuring_Optimus_PRIME:_Bus_ID_Values_.28Mandatory.29.";
       }
       {
         assertion = (cfg.hybrid.busIDs.intel != "" || cfg.hybrid.busIDs.amd != "");
-        message = "You need to define a bus ID for your non-Nvidia GPU. To learn how to find your bus ID, see https://nixos.wiki/wiki/Nvidia#Configuring_Optimus_PRIME:_Bus_ID_Values_.28Mandatory.29.";
+        message = "You need to define a bus ID for your non-Nvidia GPU. To learn how to find your bus ID, see https://wiki.nixos.org/wiki/Nvidia#Configuring_Optimus_PRIME:_Bus_ID_Values_.28Mandatory.29.";
       }
     ];
 

--- a/modules/ui/audio.nix
+++ b/modules/ui/audio.nix
@@ -14,7 +14,7 @@ in
     aux.system.ui.audio = {
       enable = lib.mkEnableOption (lib.mdDoc "Enables audio.");
       enableLowLatency = lib.mkEnableOption (
-        lib.mdDoc "Enables low-latency audio (may cause crackling) per https://nixos.wiki/wiki/PipeWire#Low-latency_setup."
+        lib.mdDoc "Enables low-latency audio (may cause crackling) per https://wiki.nixos.org/wiki/PipeWire#Low-latency_setup."
       );
     };
   };
@@ -35,7 +35,7 @@ in
       pulse.enable = true;
       jack.enable = true;
 
-      # Reduce audio latency per https://nixos.wiki/wiki/PipeWire#Low-latency_setup
+      # Reduce audio latency per https://wiki.nixos.org/wiki/PipeWire#Low-latency_setup
       extraConfig.pipewire = lib.mkIf cfg.enableLowLatency {
         "92-low-latency.conf" = {
           "context.properties" = {

--- a/modules/ui/desktops/common.nix
+++ b/modules/ui/desktops/common.nix
@@ -61,7 +61,7 @@ in
         roboto-slab
       ];
 
-      # Enable font dir for use with Flatpak. See https://nixos.wiki/wiki/Fonts#Flatpak_applications_can.27t_find_system_fonts
+      # Enable font dir for use with Flatpak. See https://wiki.nixos.org/wiki/Fonts#Flatpak_applications_can.27t_find_system_fonts
       fontDir.enable = true;
     };
 

--- a/modules/ui/desktops/gnome.nix
+++ b/modules/ui/desktops/gnome.nix
@@ -108,7 +108,7 @@ in
 
     nixpkgs.overlays = lib.mkIf cfg.tripleBuffering.enable [
       # GNOME 46: triple-buffering-v4-46
-      # For details, see https://nixos.wiki/wiki/GNOME#Dynamic_triple_buffering
+      # For details, see https://wiki.nixos.org/wiki/GNOME#Dynamic_triple_buffering
       (final: prev: {
         gnome = prev.gnome.overrideScope (
           gnomeFinal: gnomePrev: {

--- a/modules/ui/desktops/kde.nix
+++ b/modules/ui/desktops/kde.nix
@@ -22,7 +22,7 @@ in
 
     programs.dconf.enable = true;
 
-    # Fix blank messages in KMail. See https://nixos.wiki/wiki/KDE#KMail_Renders_Blank_Messages
+    # Fix blank messages in KMail. See https://wiki.nixos.org/wiki/KDE#KMail_Renders_Blank_Messages
     environment.sessionVariables = {
       NIX_PROFILES = "${pkgs.lib.concatStringsSep " " (
         pkgs.lib.reverseList config.environment.profiles


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️